### PR TITLE
Fix warnings

### DIFF
--- a/r4sGate/RK-M171S.ino
+++ b/r4sGate/RK-M171S.ino
@@ -6,7 +6,7 @@ bool m171sOff() {
 }
 
 bool m171sOn(bool boil, uint8_t temp) {
-  uint8_t data[] = { boil ? 0 : 1, 0, temp, 0 };
+  uint8_t data[] = { boil ? (uint8_t)0 : (uint8_t)1, 0, temp, 0 };
   if (r4sCommand(0x05, &data[0], sizeof(data)) != 5)
     return false;
 

--- a/r4sGate/m171s.h
+++ b/r4sGate/m171s.h
@@ -55,4 +55,4 @@ class M171SStatus {
     boolean m_valid;
 };
 
-#endif;
+#endif


### PR DESCRIPTION
- Add casts to fix "narrowing conversion" warning: This issue caused compilation to fail when **File > Preferences > Compiler warnings** was set to "More" or "All".
- Remove extra token at end of `#endif` directive.